### PR TITLE
Fix/404 everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "João Victor <santosjaoo.dev@gmail.com>",
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export -o build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/pages/user/[githubName].tsx
+++ b/pages/user/[githubName].tsx
@@ -1,31 +1,32 @@
-import { useEffect } from "react";
 import Menu from "../../src/components/Menu";
 import FabScrollTop from "../../src/components/FabScrollTop";
 import SearchInput from "../../src/components/SearchInput";
 import Card from "../../src/components/Card";
 import { Container } from "../../styles/user/style";
-import { useRouter } from "next/router";
 import { apiSearch } from "../../src/services/github";
-import { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { UserPropsSSR } from "../../src/interfaces/User";
 import { HeadElement } from "../../src/components/HeadElement";
-import { userInfo } from "os";
 
-export async function getServerSideProps(ctx:GetServerSidePropsContext<{
-  githubName: string
-}>){
-  const errorMessage = (message = "User Not Found") => ({
-    props: {
-      error: {
-        message
-      }
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if(!ctx.params)return {
+    redirect: {
+      destination: "/",
+      permanent: false
     }
-  });
-  if(!ctx.params)return errorMessage();
-  const { githubName } = ctx.params;
+  };
+  const { githubName } = ctx.params as { githubName: string };
 
-  const userInfo = await apiSearch(githubName as string);
-  if(!userInfo)return errorMessage();
+  const userInfo = await apiSearch(githubName);
+  if(!userInfo.success && !userInfo.notFound)return {
+    notFound: true
+  };
+  else if (!userInfo.success) return {
+    redirect: {
+      destination: "/500",
+      permanent: false
+    }
+  };
 
   const { 
     avatar_url, 
@@ -36,7 +37,7 @@ export async function getServerSideProps(ctx:GetServerSidePropsContext<{
     login, 
     name,
     repo
-  } = userInfo;
+  } = userInfo.payload;
 
   return {
     props: {
@@ -50,67 +51,46 @@ export async function getServerSideProps(ctx:GetServerSidePropsContext<{
         name          
       },
       repo,
-      error: {
-        message: ""
-      }
     }
   };
-}
+};
 
-function User({error, repo, userInfo: userData}: InferGetServerSidePropsType<GetServerSideProps<UserPropsSSR>>){
-  const router = useRouter();
-  useEffect(() => {
-    if(error.message !== ""){
-      router.push("/404/");
-    }
-  },[]);
+function User({repo, userInfo: userData}: InferGetServerSidePropsType<GetServerSideProps<UserPropsSSR>>){
   
   return(
     <>
-      {userData ? (
-        <>
-          <HeadElement 
-            title={`${userData.name} - Github profile`}
-            description={userData.bio}
-            url={`/user/${userData.login}`}
-            imgUrl={userData.avatar_url}
-          />
-          <Container>
-            <FabScrollTop />
-            <SearchInput />
-            <Menu
-              avatar_url={userData.avatar_url}
-              bio={userData.bio}
-              followers={userData.followers}
-              following={userData.following}
-              html_url={userData.html_url}
-              login={userData.login}
-              name={userData.name}
-            />
-            <div className="repos">
-              {repo.length >= 0 && repo.map((repoInfo, index) => (
-                <Card 
-                  key={`repo_id${index+66}`}
-                  name={repoInfo.name}
-                  description={repoInfo.description}
-                  fork={repoInfo.fork}
-                  html_url={repoInfo.html_url}
-                  language={repoInfo.language}
-                  stargazers_count={repoInfo.stargazers_count}
-                />
-              ))}
-            </div>
-          </Container>
-        </>
-      ): (
-        <HeadElement 
-          title="User not found"
-          description="Maybe this user does not exist"
-          imgUrl="https://i.ibb.co/TqhVm8R/User-not-found-thumb.png"
-          url="/404"
-          noindex
+      <HeadElement 
+        title={`${userData.name} - Github profile`}
+        description={userData.bio}
+        url={`/user/${userData.login}`}
+        imgUrl={userData.avatar_url}
+      />
+      <Container>
+        <FabScrollTop />
+        <SearchInput />
+        <Menu
+          avatar_url={userData.avatar_url}
+          bio={userData.bio}
+          followers={userData.followers}
+          following={userData.following}
+          html_url={userData.html_url}
+          login={userData.login}
+          name={userData.name}
         />
-      )}
+        <div className="repos">
+          {repo.length >= 0 && repo.map((repoInfo, index) => (
+            <Card 
+              key={`repo_id${index+66}`}
+              name={repoInfo.name}
+              description={repoInfo.description}
+              fork={repoInfo.fork}
+              html_url={repoInfo.html_url}
+              language={repoInfo.language}
+              stargazers_count={repoInfo.stargazers_count}
+            />
+          ))}
+        </div>
+      </Container>
     </>
   );
 }


### PR DESCRIPTION
- Mudando o comando de build pra somente next build 
- Mudando o serviço da API do github para dar um return com um pouco mais de info e gerenciar erros de 404 da API melhor
- Adaptando a pagina de perfil do usuário ao novo serviço
- Adaptando a pagina de usuário para redirecionar a paginas de erro antes mesmo de renderizar/enviar página 

Não corrigido: 
- (não tenho ctz se isso é só no meu ambiente mesmo, ou em todo lugar): stall infinito ao acessar algumas rotas ou fazer pesquisa de usuários. Possíveis pbs ? 1- Erro ao falar com a API do gh, 2- Algum erro do github não handled, 3- API do github sendo chama infinitamente de novo e de novo ...